### PR TITLE
Add analytics module for Power BI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,19 @@ CLIENT_SECRET=
 -   Frontend: http://localhost:4000
 -   Backend: http://localhost:8000
 
+## Power BI Dashboard Integration
+
+The backend exposes a sample analytics endpoint that returns sales data for
+demonstrating data visualization with Power BI. You can access the data at:
+
+```
+http://localhost:8000/api/analytics/sales-data
+```
+
+In Power BI Desktop, choose **Get Data > Web** and enter the above URL. After the
+data loads, build visualizations such as bar or pie charts using the retrieved
+categories and sales values.
+
 ## Recommended Branching Strategy
 
 This document outlines a solid branching strategy for your Nx monorepo architecture, considering

--- a/apps/backend/src/modules/analytics/analytics.controller.spec.ts
+++ b/apps/backend/src/modules/analytics/analytics.controller.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsController', () => {
+    let controller: AnalyticsController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [AnalyticsController],
+            providers: [AnalyticsService]
+        }).compile();
+
+        controller = module.get<AnalyticsController>(AnalyticsController);
+    });
+
+    it('should return sample sales data', () => {
+        const data = controller.getSalesData();
+        expect(data.length).toBeGreaterThan(0);
+        expect(data[0]).toHaveProperty('category');
+        expect(data[0]).toHaveProperty('sales');
+    });
+});

--- a/apps/backend/src/modules/analytics/analytics.controller.ts
+++ b/apps/backend/src/modules/analytics/analytics.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { BaseMessage } from '@full-stack-project/shared';
+import { AnalyticsService, SalesData } from './analytics.service';
+
+@Controller('analytics')
+export class AnalyticsController {
+    constructor(private readonly analyticsService: AnalyticsService) {}
+
+    @Get('sales-data')
+    @ApiOperation({ summary: 'Sales data for Power BI dashboard.' })
+    @ApiResponse({
+        status: BaseMessage.SwaggerMessage.Response.Ok.Status,
+        description: BaseMessage.SwaggerMessage.Response.Ok.Description
+    })
+    getSalesData(): SalesData[] {
+        return this.analyticsService.getSalesData();
+    }
+}

--- a/apps/backend/src/modules/analytics/analytics.module.ts
+++ b/apps/backend/src/modules/analytics/analytics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+@Module({
+    controllers: [AnalyticsController],
+    providers: [AnalyticsService],
+    exports: [AnalyticsService]
+})
+export class AnalyticsModule {}

--- a/apps/backend/src/modules/analytics/analytics.service.ts
+++ b/apps/backend/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+
+export interface SalesData {
+    category: string;
+    sales: number;
+}
+
+@Injectable()
+export class AnalyticsService {
+    getSalesData(): SalesData[] {
+        return [
+            { category: 'Electronics', sales: 1200 },
+            { category: 'Clothes', sales: 900 },
+            { category: 'Home', sales: 600 }
+        ];
+    }
+}

--- a/apps/backend/src/modules/analytics/index.ts
+++ b/apps/backend/src/modules/analytics/index.ts
@@ -1,0 +1,3 @@
+export * from './analytics.module';
+export * from './analytics.controller';
+export * from './analytics.service';

--- a/apps/backend/src/modules/app.module.ts
+++ b/apps/backend/src/modules/app.module.ts
@@ -4,6 +4,7 @@ import { TerminusModule } from '@nestjs/terminus';
 import { environment } from '../config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AnalyticsModule } from './analytics';
 
 @Module({
     imports: [
@@ -13,7 +14,8 @@ import { AppService } from './app.service';
             ignoreEnvFile: true,
             load: [environment]
         }),
-        TerminusModule
+        TerminusModule,
+        AnalyticsModule
     ],
     controllers: [AppController],
     providers: [AppService]


### PR DESCRIPTION
## Summary
- provide an `/analytics/sales-data` endpoint
- wire up the new module in the backend
- explain how to connect Power BI to the new endpoint

## Testing
- `npm run backend:test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ec1e4d7048321b56b66f17b3337db