### PR TITLE
Add RestApiService call test

### DIFF
--- a/apps/frontend/src/modules/app.component.spec.ts
+++ b/apps/frontend/src/modules/app.component.spec.ts
@@ -1,25 +1,52 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
-import { AppRoutingModule } from './app-routing.module';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
-import { SharedModule } from './shared/shared.module';
+import { RestApiService } from './shared/services';
+import { ApiRoute } from './shared/constants';
+import { NGXLogger } from 'ngx-logger';
+import { CONFIG } from '../config/config';
+import { IBaseResponse } from '@full-stack-project/shared';
 
 describe('AppComponent', () => {
     let component: AppComponent;
     let fixture: ComponentFixture<AppComponent>;
+    let restApiService: jasmine.SpyObj<RestApiService>;
+    let loggerService: jasmine.SpyObj<NGXLogger>;
 
     beforeEach(async () => {
+        const response: IBaseResponse<{ Information: string }> = {
+            IsSuccess: true,
+            Message: '',
+            Data: { Information: 'test-information' },
+            Errors: []
+        };
+
+        restApiService = jasmine.createSpyObj('RestApiService', ['get']);
+        restApiService.get.and.resolveTo(response);
+        loggerService = jasmine.createSpyObj('NGXLogger', ['info', 'error']);
+
         await TestBed.configureTestingModule({
             declarations: [AppComponent],
-            imports: [SharedModule, BrowserModule, AppRoutingModule]
+            imports: [BrowserModule, RouterTestingModule],
+            providers: [
+                { provide: RestApiService, useValue: restApiService },
+                { provide: NGXLogger, useValue: loggerService }
+            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(AppComponent);
         component = fixture.componentInstance;
-        fixture.detectChanges();
     });
 
-    it(`It should success, app component`, () => {
-        expect(component).toBeTruthy();
+    it('should call RestApiService.get and handle response', async () => {
+        await component.ngOnInit();
+
+        expect(restApiService.get).toHaveBeenCalledWith(ApiRoute.Base.RootRoute);
+        expect(loggerService.info).toHaveBeenCalledWith(
+            `Frontend application starts successfully for ${CONFIG.environment} environment`
+        );
+        expect(loggerService.info).toHaveBeenCalledWith('test-information');
+        expect(loggerService.error).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- expand `AppComponent` test
- mock `RestApiService` and verify its usage
- assert log handling of successful response

## Testing
- `npm run frontend:test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ec29021a48321ac6e5a152ed5902f